### PR TITLE
build(all): security audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,21 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@aws-cdk/asset-awscli-v1": {
+      "version": "2.2.151",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.151.tgz",
+      "integrity": "sha512-/+sjJeSgUjL+ZSbGP84I0fqreQxQnPC2mXemBd+ZADZW87reIIXG1u1ZICeBhaY12fg4iFbshGfRVAkOo3QgYw=="
+    },
+    "node_modules/@aws-cdk/asset-kubectl-v20": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.1.tgz",
+      "integrity": "sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw=="
+    },
+    "node_modules/@aws-cdk/asset-node-proxy-agent-v5": {
+      "version": "2.0.126",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.126.tgz",
+      "integrity": "sha512-NzMIFA6VdX0JDnTU3UPZhwYC/tQqSn5yEeDNfACxoiZ4Ey+z8pIkQ3DBldqdAw8+YMKxblmyaA6pBy2xzqLLOg=="
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
@@ -1803,9 +1818,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.43.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.43.1.tgz",
-      "integrity": "sha512-Sss4qcGAdTTTLHHG2ytjPqfOJRy3z17BnuEmlk7UukMBl1KRusfSYDvYWeN78+v6gMT+0BVlUaLzggdxgo3V+w==",
+      "version": "2.76.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.76.0.tgz",
+      "integrity": "sha512-EYWdHh/qJA7v+jD6SeW+BOEChI7oe6IYPHHap+SoJMUrKBVSDKnIGJ8wTP5eV6F27aYaUQiA7rWTKcCWoda8ag==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1815,17 +1830,22 @@
         "minimatch",
         "punycode",
         "semver",
+        "table",
         "yaml"
       ],
       "dependencies": {
+        "@aws-cdk/asset-awscli-v1": "^2.2.97",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.77",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
-        "ignore": "^5.2.0",
+        "ignore": "^5.2.4",
         "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
-        "punycode": "^2.1.1",
-        "semver": "^7.3.7",
+        "punycode": "^2.3.0",
+        "semver": "^7.3.8",
+        "table": "^6.8.1",
         "yaml": "1.10.2"
       },
       "engines": {
@@ -1839,6 +1859,51 @@
       "version": "1.0.2",
       "inBundle": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ajv": {
+      "version": "8.12.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/aws-cdk-lib/node_modules/at-least-node": {
       "version": "1.0.0",
@@ -1870,8 +1935,34 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/color-convert": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-name": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/aws-cdk-lib/node_modules/concat-map": {
       "version": "0.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
       "inBundle": true,
       "license": "MIT"
     },
@@ -1895,12 +1986,25 @@
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.2.0",
+      "version": "5.2.4",
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
       "version": "6.1.0",
@@ -1920,6 +2024,11 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/lru-cache": {
       "version": "6.0.0",
@@ -1944,15 +2053,23 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
-      "version": "2.1.1",
+      "version": "2.3.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/require-from-string": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.3.7",
+      "version": "7.3.8",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -1965,12 +2082,75 @@
         "node": ">=10"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/string-width": {
+      "version": "4.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/table": {
+      "version": "6.8.1",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
       "version": "2.0.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/uri-js": {
+      "version": "4.4.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/yallist": {
@@ -1987,9 +2167,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1204.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1204.0.tgz",
-      "integrity": "sha512-H3dRQBdgzAfZ/e/dfiW44fhQrgAuCfIzWhI5y5J9122caI4uZY6TEUd003UXP4nXq2eMfuPWg0bA/mPwbj8RkA==",
+      "version": "2.1364.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1364.0.tgz",
+      "integrity": "sha512-PFoq9Rnu0DVi07wZ/SjKlrJDwso8AxE5q/ufLdNtINZPaSkB92OqKYVdlfQ4srsH2ala2NCrg8gFX98SCmqW3w==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -2000,7 +2180,7 @@
         "url": "0.10.3",
         "util": "^0.12.4",
         "uuid": "8.0.0",
-        "xml2js": "0.4.19"
+        "xml2js": "0.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
@@ -2307,18 +2487,18 @@
       ]
     },
     "node_modules/cdk-nag": {
-      "version": "2.16.6",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.16.6.tgz",
-      "integrity": "sha512-uBQKSoDc1/otTWo4pchvUpH2JrIL9nrCuR7A5T92q1RXmFWhURGXHwZ8+AuYHMh9w0e4jMTwZPch9oCJKqZUcg==",
+      "version": "2.26.5",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.26.5.tgz",
+      "integrity": "sha512-s0MKhHMlFd+4O6O6Itq1XI6DiAaakbUDN4QVPkkJtKKnm9sZg1RkbULM9i+aGMjqCRviv9pmn2iDgzOJNaOgkA==",
       "peerDependencies": {
-        "aws-cdk-lib": "^2.18.0",
+        "aws-cdk-lib": "^2.45.0",
         "constructs": "^10.0.5"
       }
     },
     "node_modules/cdk-remote-stack": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/cdk-remote-stack/-/cdk-remote-stack-2.0.9.tgz",
-      "integrity": "sha512-UQFuFWsECJFW8pwV+Z4M3pCu8Mwg7bG/a0km0B7/gFhcX9dHLlq5P9MgoJ4fubZ38BKx4fZhGdNI6jnEfwIE0w==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/cdk-remote-stack/-/cdk-remote-stack-2.0.10.tgz",
+      "integrity": "sha512-Fu2/1xGBgNAPHzc25F6QTc5fv2u+gjzzXQNXwcADHA580AGH8IccEmRtdXy8ovg7+NbffBvbo3UxFMZVLeBciQ==",
       "peerDependencies": {
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.5"
@@ -4659,7 +4839,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -6366,7 +6545,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -7168,7 +7346,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -7609,7 +7786,6 @@
       "version": "7.3.7",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
       "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -8830,18 +9006,21 @@
       "dev": true
     },
     "node_modules/xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dependencies": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "engines": {
         "node": ">=4.0"
       }
@@ -8873,13 +9052,12 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
-      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
       "dev": true,
       "engines": {
         "node": ">= 14"
@@ -9194,6 +9372,21 @@
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
       }
+    },
+    "@aws-cdk/asset-awscli-v1": {
+      "version": "2.2.151",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.151.tgz",
+      "integrity": "sha512-/+sjJeSgUjL+ZSbGP84I0fqreQxQnPC2mXemBd+ZADZW87reIIXG1u1ZICeBhaY12fg4iFbshGfRVAkOo3QgYw=="
+    },
+    "@aws-cdk/asset-kubectl-v20": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.1.tgz",
+      "integrity": "sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw=="
+    },
+    "@aws-cdk/asset-node-proxy-agent-v5": {
+      "version": "2.0.126",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.126.tgz",
+      "integrity": "sha512-NzMIFA6VdX0JDnTU3UPZhwYC/tQqSn5yEeDNfACxoiZ4Ey+z8pIkQ3DBldqdAw8+YMKxblmyaA6pBy2xzqLLOg=="
     },
     "@babel/code-frame": {
       "version": "7.18.6",
@@ -10522,23 +10715,52 @@
       }
     },
     "aws-cdk-lib": {
-      "version": "2.43.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.43.1.tgz",
-      "integrity": "sha512-Sss4qcGAdTTTLHHG2ytjPqfOJRy3z17BnuEmlk7UukMBl1KRusfSYDvYWeN78+v6gMT+0BVlUaLzggdxgo3V+w==",
+      "version": "2.76.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.76.0.tgz",
+      "integrity": "sha512-EYWdHh/qJA7v+jD6SeW+BOEChI7oe6IYPHHap+SoJMUrKBVSDKnIGJ8wTP5eV6F27aYaUQiA7rWTKcCWoda8ag==",
       "requires": {
+        "@aws-cdk/asset-awscli-v1": "^2.2.97",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.77",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
-        "ignore": "^5.2.0",
+        "ignore": "^5.2.4",
         "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
-        "punycode": "^2.1.1",
-        "semver": "^7.3.7",
+        "punycode": "^2.3.0",
+        "semver": "^7.3.8",
+        "table": "^6.8.1",
         "yaml": "1.10.2"
       },
       "dependencies": {
         "@balena/dockerignore": {
           "version": "1.0.2",
+          "bundled": true
+        },
+        "ajv": {
+          "version": "8.12.0",
+          "bundled": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "bundled": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "astral-regex": {
+          "version": "2.0.0",
           "bundled": true
         },
         "at-least-node": {
@@ -10561,8 +10783,27 @@
           "version": "1.6.3",
           "bundled": true
         },
+        "color-convert": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "bundled": true
+        },
         "concat-map": {
           "version": "0.0.1",
+          "bundled": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "bundled": true
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
           "bundled": true
         },
         "fs-extra": {
@@ -10580,7 +10821,15 @@
           "bundled": true
         },
         "ignore": {
-          "version": "5.2.0",
+          "version": "5.2.4",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
           "bundled": true
         },
         "jsonfile": {
@@ -10593,6 +10842,10 @@
         },
         "jsonschema": {
           "version": "1.4.1",
+          "bundled": true
+        },
+        "lodash.truncate": {
+          "version": "4.4.2",
           "bundled": true
         },
         "lru-cache": {
@@ -10610,19 +10863,66 @@
           }
         },
         "punycode": {
-          "version": "2.1.1",
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "require-from-string": {
+          "version": "2.0.2",
           "bundled": true
         },
         "semver": {
-          "version": "7.3.7",
+          "version": "7.3.8",
           "bundled": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
+        "slice-ansi": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "bundled": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "table": {
+          "version": "6.8.1",
+          "bundled": true,
+          "requires": {
+            "ajv": "^8.0.1",
+            "lodash.truncate": "^4.4.2",
+            "slice-ansi": "^4.0.0",
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1"
+          }
+        },
         "universalify": {
           "version": "2.0.0",
           "bundled": true
+        },
+        "uri-js": {
+          "version": "4.4.1",
+          "bundled": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
         },
         "yallist": {
           "version": "4.0.0",
@@ -10635,9 +10935,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.1204.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1204.0.tgz",
-      "integrity": "sha512-H3dRQBdgzAfZ/e/dfiW44fhQrgAuCfIzWhI5y5J9122caI4uZY6TEUd003UXP4nXq2eMfuPWg0bA/mPwbj8RkA==",
+      "version": "2.1364.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1364.0.tgz",
+      "integrity": "sha512-PFoq9Rnu0DVi07wZ/SjKlrJDwso8AxE5q/ufLdNtINZPaSkB92OqKYVdlfQ4srsH2ala2NCrg8gFX98SCmqW3w==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -10648,7 +10948,7 @@
         "url": "0.10.3",
         "util": "^0.12.4",
         "uuid": "8.0.0",
-        "xml2js": "0.4.19"
+        "xml2js": "0.5.0"
       }
     },
     "babel-jest": {
@@ -10988,15 +11288,15 @@
       "dev": true
     },
     "cdk-nag": {
-      "version": "2.16.6",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.16.6.tgz",
-      "integrity": "sha512-uBQKSoDc1/otTWo4pchvUpH2JrIL9nrCuR7A5T92q1RXmFWhURGXHwZ8+AuYHMh9w0e4jMTwZPch9oCJKqZUcg==",
+      "version": "2.26.5",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.26.5.tgz",
+      "integrity": "sha512-s0MKhHMlFd+4O6O6Itq1XI6DiAaakbUDN4QVPkkJtKKnm9sZg1RkbULM9i+aGMjqCRviv9pmn2iDgzOJNaOgkA==",
       "requires": {}
     },
     "cdk-remote-stack": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/cdk-remote-stack/-/cdk-remote-stack-2.0.9.tgz",
-      "integrity": "sha512-UQFuFWsECJFW8pwV+Z4M3pCu8Mwg7bG/a0km0B7/gFhcX9dHLlq5P9MgoJ4fubZ38BKx4fZhGdNI6jnEfwIE0w==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/cdk-remote-stack/-/cdk-remote-stack-2.0.10.tgz",
+      "integrity": "sha512-Fu2/1xGBgNAPHzc25F6QTc5fv2u+gjzzXQNXwcADHA580AGH8IccEmRtdXy8ovg7+NbffBvbo3UxFMZVLeBciQ==",
       "requires": {}
     },
     "chalk": {
@@ -12688,8 +12988,7 @@
     "ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-      "dev": true
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -13944,7 +14243,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -14535,8 +14833,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "q": {
       "version": "1.5.1",
@@ -14853,7 +15150,6 @@
       "version": "7.3.7",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
       "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -15759,18 +16055,18 @@
       "dev": true
     },
     "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "requires": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "xmlbuilder": "~11.0.0"
       }
     },
     "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ=="
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xmlchars": {
       "version": "2.2.0",
@@ -15793,13 +16089,12 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
-      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
       "dev": true
     },
     "yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@types/node": "18.7.14",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
-        "cdk-nag": "^2.15.38",
+        "cdk-nag": "^2.26.5",
         "eslint": "^8.23.1",
         "eslint-config-prettier": "^8.5.0",
         "lint-staged": "^13.0.3",
@@ -1803,9 +1803,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.43.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.43.1.tgz",
-      "integrity": "sha512-Y+Pomc+LdQ14h+CvFZg+FeqcLpV8MJcoFhqcoOtGi0xC8CkdGAWH+MfIWcqePk7OVOMIzDJP2eBdd9te2CrjcQ==",
+      "version": "2.77.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.77.0.tgz",
+      "integrity": "sha512-f0UpWjBxrFkINqlwL50OpIIC03V39hTzg4+NEBlfUc/ftFX8WQQYyT6h29IfxT9Tgo+YoEMlM1nnH/s1c+VKSw==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -4839,6 +4839,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -6545,6 +6546,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -7346,6 +7348,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -7786,6 +7789,7 @@
       "version": "7.3.7",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
       "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -9052,7 +9056,8 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yaml": {
       "version": "2.2.2",
@@ -9145,8 +9150,8 @@
       "version": "1.0.0",
       "license": "MIT-0",
       "dependencies": {
-        "aws-cdk-lib": "^2.43.1",
-        "constructs": "^10.1.99",
+        "aws-cdk-lib": "^2.76.0",
+        "constructs": "^10.1.115",
         "source-map-support": "^0.5.21"
       },
       "bin": {
@@ -9157,7 +9162,7 @@
         "@types/node": "18.7.14",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
-        "aws-cdk": "^2.43.1",
+        "aws-cdk": "^2.76.0",
         "eslint": "^8.23.1",
         "eslint-config-prettier": "^8.5.0",
         "jest": "^27.5.1",
@@ -9172,8 +9177,8 @@
       "version": "1.0.0",
       "license": "MIT-0",
       "dependencies": {
-        "aws-cdk-lib": "^2.43.1",
-        "constructs": "^10.1.99",
+        "aws-cdk-lib": "^2.76.0",
+        "constructs": "^10.1.115",
         "source-map-support": "^0.5.21"
       },
       "bin": {
@@ -9184,7 +9189,7 @@
         "@types/node": "18.7.14",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
-        "aws-cdk": "^2.43.1",
+        "aws-cdk": "^2.76.0",
         "eslint": "^8.23.1",
         "eslint-config-prettier": "^8.5.0",
         "jest": "^27.5.1",
@@ -9199,8 +9204,8 @@
       "version": "1.0.0",
       "license": "MIT-0",
       "dependencies": {
-        "aws-cdk-lib": "^2.43.1",
-        "constructs": "^10.1.99",
+        "aws-cdk-lib": "^2.76.0",
+        "constructs": "^10.1.115",
         "source-map-support": "^0.5.21"
       },
       "bin": {
@@ -9211,7 +9216,7 @@
         "@types/node": "18.7.14",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
-        "aws-cdk": "^2.43.1",
+        "aws-cdk": "^2.76.0",
         "eslint": "^8.23.1",
         "eslint-config-prettier": "^8.5.0",
         "jest": "^27.5.1",
@@ -9226,8 +9231,8 @@
       "version": "1.0.0",
       "license": "MIT-0",
       "dependencies": {
-        "aws-cdk-lib": "^2.43.1",
-        "constructs": "^10.1.99",
+        "aws-cdk-lib": "^2.76.0",
+        "constructs": "^10.1.115",
         "source-map-support": "^0.5.21"
       },
       "bin": {
@@ -9238,7 +9243,7 @@
         "@types/node": "18.7.14",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
-        "aws-cdk": "^2.43.1",
+        "aws-cdk": "^2.76.0",
         "esbuild": "^0.15.9",
         "eslint": "^8.23.1",
         "eslint-config-prettier": "^8.5.0",
@@ -9254,11 +9259,11 @@
       "version": "0.1.0",
       "license": "MIT-0",
       "dependencies": {
-        "aws-cdk-lib": "^2.43.1",
-        "aws-sdk": "^2.1189.0",
-        "cdk-nag": "^2.15.38",
+        "aws-cdk-lib": "^2.76.0",
+        "aws-sdk": "^2.1364.0",
+        "cdk-nag": "^2.26.5",
         "cdk-remote-stack": "^2.0.9",
-        "constructs": "^10.1.99",
+        "constructs": "^10.1.115",
         "source-map-support": "^0.5.21"
       },
       "bin": {
@@ -9270,7 +9275,7 @@
         "@types/node": "18.7.14",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
-        "aws-cdk": "^2.43.1",
+        "aws-cdk": "^2.76.0",
         "esbuild": "^0.15.9",
         "eslint": "^8.23.1",
         "eslint-config-prettier": "^8.5.0",
@@ -9286,8 +9291,8 @@
       "version": "1.0.0",
       "license": "MIT-0",
       "dependencies": {
-        "aws-cdk-lib": "^2.43.1",
-        "constructs": "^10.1.99",
+        "aws-cdk-lib": "^2.76.0",
+        "constructs": "^10.1.115",
         "source-map-support": "^0.5.21"
       },
       "bin": {
@@ -9298,7 +9303,7 @@
         "@types/node": "18.7.14",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
-        "aws-cdk": "^2.43.1",
+        "aws-cdk": "^2.76.0",
         "eslint": "^8.23.1",
         "eslint-config-prettier": "^8.5.0",
         "jest": "^27.5.1",
@@ -9313,8 +9318,8 @@
       "version": "1.0.0",
       "license": "MIT-0",
       "dependencies": {
-        "aws-cdk-lib": "^2.43.1",
-        "constructs": "^10.1.99",
+        "aws-cdk-lib": "^2.76.0",
+        "constructs": "^10.1.115",
         "source-map-support": "^0.5.21"
       },
       "bin": {
@@ -9325,7 +9330,7 @@
         "@types/node": "18.7.14",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
-        "aws-cdk": "^2.43.1",
+        "aws-cdk": "^2.76.0",
         "eslint": "^8.23.1",
         "eslint-config-prettier": "^8.5.0",
         "jest": "^27.5.1",
@@ -9339,8 +9344,8 @@
       "version": "1.0.0",
       "license": "MIT-0",
       "dependencies": {
-        "aws-cdk-lib": "^2.43.1",
-        "constructs": "^10.1.99",
+        "aws-cdk-lib": "^2.76.0",
+        "constructs": "^10.1.115",
         "source-map-support": "^0.5.21"
       },
       "bin": {
@@ -9351,7 +9356,7 @@
         "@types/node": "18.7.14",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
-        "aws-cdk": "^2.43.1",
+        "aws-cdk": "^2.76.0",
         "eslint": "^8.23.1",
         "eslint-config-prettier": "^8.5.0",
         "jest": "^27.5.1",
@@ -10706,9 +10711,9 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
     "aws-cdk": {
-      "version": "2.43.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.43.1.tgz",
-      "integrity": "sha512-Y+Pomc+LdQ14h+CvFZg+FeqcLpV8MJcoFhqcoOtGi0xC8CkdGAWH+MfIWcqePk7OVOMIzDJP2eBdd9te2CrjcQ==",
+      "version": "2.77.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.77.0.tgz",
+      "integrity": "sha512-f0UpWjBxrFkINqlwL50OpIIC03V39hTzg4+NEBlfUc/ftFX8WQQYyT6h29IfxT9Tgo+YoEMlM1nnH/s1c+VKSw==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2"
@@ -11040,9 +11045,9 @@
         "@types/node": "18.7.14",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
-        "aws-cdk": "^2.43.1",
-        "aws-cdk-lib": "^2.43.1",
-        "constructs": "^10.1.99",
+        "aws-cdk": "^2.76.0",
+        "aws-cdk-lib": "^2.76.0",
+        "constructs": "^10.1.115",
         "eslint": "^8.23.1",
         "eslint-config-prettier": "^8.5.0",
         "jest": "^27.5.1",
@@ -11060,9 +11065,9 @@
         "@types/node": "18.7.14",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
-        "aws-cdk": "^2.43.1",
-        "aws-cdk-lib": "^2.43.1",
-        "constructs": "^10.1.99",
+        "aws-cdk": "^2.76.0",
+        "aws-cdk-lib": "^2.76.0",
+        "constructs": "^10.1.115",
         "eslint": "^8.23.1",
         "eslint-config-prettier": "^8.5.0",
         "jest": "^27.5.1",
@@ -11080,9 +11085,9 @@
         "@types/node": "18.7.14",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
-        "aws-cdk": "^2.43.1",
-        "aws-cdk-lib": "^2.43.1",
-        "constructs": "^10.1.99",
+        "aws-cdk": "^2.76.0",
+        "aws-cdk-lib": "^2.76.0",
+        "constructs": "^10.1.115",
         "eslint": "^8.23.1",
         "eslint-config-prettier": "^8.5.0",
         "jest": "^27.5.1",
@@ -11100,9 +11105,9 @@
         "@types/node": "18.7.14",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
-        "aws-cdk": "^2.43.1",
-        "aws-cdk-lib": "^2.43.1",
-        "constructs": "^10.1.99",
+        "aws-cdk": "^2.76.0",
+        "aws-cdk-lib": "^2.76.0",
+        "constructs": "^10.1.115",
         "esbuild": "^0.15.9",
         "eslint": "^8.23.1",
         "eslint-config-prettier": "^8.5.0",
@@ -11122,12 +11127,12 @@
         "@types/node": "18.7.14",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
-        "aws-cdk": "^2.43.1",
-        "aws-cdk-lib": "^2.43.1",
-        "aws-sdk": "^2.1189.0",
-        "cdk-nag": "^2.15.38",
+        "aws-cdk": "^2.76.0",
+        "aws-cdk-lib": "^2.76.0",
+        "aws-sdk": "^2.1364.0",
+        "cdk-nag": "^2.26.5",
         "cdk-remote-stack": "^2.0.9",
-        "constructs": "^10.1.99",
+        "constructs": "^10.1.115",
         "esbuild": "^0.15.9",
         "eslint": "^8.23.1",
         "eslint-config-prettier": "^8.5.0",
@@ -11146,9 +11151,9 @@
         "@types/node": "18.7.14",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
-        "aws-cdk": "^2.43.1",
-        "aws-cdk-lib": "^2.43.1",
-        "constructs": "^10.1.99",
+        "aws-cdk": "^2.76.0",
+        "aws-cdk-lib": "^2.76.0",
+        "constructs": "^10.1.115",
         "eslint": "^8.23.1",
         "eslint-config-prettier": "^8.5.0",
         "jest": "^27.5.1",
@@ -11166,9 +11171,9 @@
         "@types/node": "18.7.14",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
-        "aws-cdk": "^2.43.1",
-        "aws-cdk-lib": "^2.43.1",
-        "constructs": "^10.1.99",
+        "aws-cdk": "^2.76.0",
+        "aws-cdk-lib": "^2.76.0",
+        "constructs": "^10.1.115",
         "eslint": "^8.23.1",
         "eslint-config-prettier": "^8.5.0",
         "jest": "^27.5.1",
@@ -12848,9 +12853,9 @@
         "@types/node": "18.7.14",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
-        "aws-cdk": "^2.43.1",
-        "aws-cdk-lib": "^2.43.1",
-        "constructs": "^10.1.99",
+        "aws-cdk": "^2.76.0",
+        "aws-cdk-lib": "^2.76.0",
+        "constructs": "^10.1.115",
         "eslint": "^8.23.1",
         "eslint-config-prettier": "^8.5.0",
         "jest": "^27.5.1",
@@ -12988,7 +12993,8 @@
     "ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "dev": true
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -14243,6 +14249,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -14833,7 +14840,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "q": {
       "version": "1.5.1",
@@ -15150,6 +15158,7 @@
       "version": "7.3.7",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
       "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -16089,7 +16098,8 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "yaml": {
       "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/node": "18.7.14",
     "@typescript-eslint/eslint-plugin": "^5.38.0",
     "@typescript-eslint/parser": "^5.38.0",
-    "cdk-nag": "^2.15.38",
+    "cdk-nag": "^2.26.5",
     "eslint": "^8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "lint-staged": "^13.0.3",

--- a/usecases/base-ct-guest-osa/package.json
+++ b/usecases/base-ct-guest-osa/package.json
@@ -22,7 +22,7 @@
     "@types/node": "18.7.14",
     "@typescript-eslint/eslint-plugin": "^5.38.0",
     "@typescript-eslint/parser": "^5.38.0",
-    "aws-cdk": "^2.43.1",
+    "aws-cdk": "^2.76.0",
     "eslint": "^8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "jest": "^27.5.1",
@@ -32,8 +32,8 @@
     "typescript": "~4.8.3"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.43.1",
-    "constructs": "^10.1.99",
+    "aws-cdk-lib": "^2.76.0",
+    "constructs": "^10.1.115",
     "source-map-support": "^0.5.21"
   }
 }

--- a/usecases/base-ct-guest-osa/test/__snapshots__/bleafsi-base-ct-guest.test.ts.snap
+++ b/usecases/base-ct-guest-osa/test/__snapshots__/bleafsi-base-ct-guest.test.ts.snap
@@ -55,17 +55,7 @@ Object {
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Principal": Object {
-                "Service": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "ec2.",
-                      Object {
-                        "Ref": "AWS::URLSuffix",
-                      },
-                    ],
-                  ],
-                },
+                "Service": "ec2.amazonaws.com",
               },
             },
           ],
@@ -173,17 +163,7 @@ Object {
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Principal": Object {
-                "Service": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "ec2.",
-                      Object {
-                        "Ref": "AWS::URLSuffix",
-                      },
-                    ],
-                  ],
-                },
+                "Service": "ec2.amazonaws.com",
               },
             },
           ],
@@ -298,17 +278,7 @@ Object {
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Principal": Object {
-                "Service": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "ec2.",
-                      Object {
-                        "Ref": "AWS::URLSuffix",
-                      },
-                    ],
-                  ],
-                },
+                "Service": "ec2.amazonaws.com",
               },
             },
           ],
@@ -390,17 +360,7 @@ Object {
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Principal": Object {
-                "Service": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "ec2.",
-                      Object {
-                        "Ref": "AWS::URLSuffix",
-                      },
-                    ],
-                  ],
-                },
+                "Service": "ec2.amazonaws.com",
               },
             },
           ],

--- a/usecases/base-ct-guest/package.json
+++ b/usecases/base-ct-guest/package.json
@@ -22,7 +22,7 @@
     "@types/node": "18.7.14",
     "@typescript-eslint/eslint-plugin": "^5.38.0",
     "@typescript-eslint/parser": "^5.38.0",
-    "aws-cdk": "^2.43.1",
+    "aws-cdk": "^2.76.0",
     "eslint": "^8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "jest": "^27.5.1",
@@ -32,8 +32,8 @@
     "typescript": "~4.8.3"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.43.1",
-    "constructs": "^10.1.99",
+    "aws-cdk-lib": "^2.76.0",
+    "constructs": "^10.1.115",
     "source-map-support": "^0.5.21"
   }
 }

--- a/usecases/base-ct-guest/test/__snapshots__/bleafsi-base-ct-guest.test.ts.snap
+++ b/usecases/base-ct-guest/test/__snapshots__/bleafsi-base-ct-guest.test.ts.snap
@@ -55,17 +55,7 @@ Object {
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Principal": Object {
-                "Service": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "ec2.",
-                      Object {
-                        "Ref": "AWS::URLSuffix",
-                      },
-                    ],
-                  ],
-                },
+                "Service": "ec2.amazonaws.com",
               },
             },
           ],
@@ -173,17 +163,7 @@ Object {
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Principal": Object {
-                "Service": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "ec2.",
-                      Object {
-                        "Ref": "AWS::URLSuffix",
-                      },
-                    ],
-                  ],
-                },
+                "Service": "ec2.amazonaws.com",
               },
             },
           ],
@@ -298,17 +278,7 @@ Object {
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Principal": Object {
-                "Service": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "ec2.",
-                      Object {
-                        "Ref": "AWS::URLSuffix",
-                      },
-                    ],
-                  ],
-                },
+                "Service": "ec2.amazonaws.com",
               },
             },
           ],
@@ -390,17 +360,7 @@ Object {
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Principal": Object {
-                "Service": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "ec2.",
-                      Object {
-                        "Ref": "AWS::URLSuffix",
-                      },
-                    ],
-                  ],
-                },
+                "Service": "ec2.amazonaws.com",
               },
             },
           ],
@@ -447,100 +407,6 @@ Object {
 
 exports[`BLEA-FSI-BASE ControlTower Stacks GuestAccount Stacks 2`] = `
 Object {
-  "Mappings": Object {
-    "ServiceprincipalMap": Object {
-      "af-south-1": Object {
-        "ssm": "ssm.af-south-1.amazonaws.com",
-      },
-      "ap-east-1": Object {
-        "ssm": "ssm.ap-east-1.amazonaws.com",
-      },
-      "ap-northeast-1": Object {
-        "ssm": "ssm.amazonaws.com",
-      },
-      "ap-northeast-2": Object {
-        "ssm": "ssm.amazonaws.com",
-      },
-      "ap-northeast-3": Object {
-        "ssm": "ssm.amazonaws.com",
-      },
-      "ap-south-1": Object {
-        "ssm": "ssm.amazonaws.com",
-      },
-      "ap-southeast-1": Object {
-        "ssm": "ssm.amazonaws.com",
-      },
-      "ap-southeast-2": Object {
-        "ssm": "ssm.amazonaws.com",
-      },
-      "ap-southeast-3": Object {
-        "ssm": "ssm.ap-southeast-3.amazonaws.com",
-      },
-      "ca-central-1": Object {
-        "ssm": "ssm.amazonaws.com",
-      },
-      "cn-north-1": Object {
-        "ssm": "ssm.amazonaws.com",
-      },
-      "cn-northwest-1": Object {
-        "ssm": "ssm.amazonaws.com",
-      },
-      "eu-central-1": Object {
-        "ssm": "ssm.amazonaws.com",
-      },
-      "eu-north-1": Object {
-        "ssm": "ssm.amazonaws.com",
-      },
-      "eu-south-1": Object {
-        "ssm": "ssm.eu-south-1.amazonaws.com",
-      },
-      "eu-south-2": Object {
-        "ssm": "ssm.eu-south-2.amazonaws.com",
-      },
-      "eu-west-1": Object {
-        "ssm": "ssm.amazonaws.com",
-      },
-      "eu-west-2": Object {
-        "ssm": "ssm.amazonaws.com",
-      },
-      "eu-west-3": Object {
-        "ssm": "ssm.amazonaws.com",
-      },
-      "me-south-1": Object {
-        "ssm": "ssm.me-south-1.amazonaws.com",
-      },
-      "sa-east-1": Object {
-        "ssm": "ssm.amazonaws.com",
-      },
-      "us-east-1": Object {
-        "ssm": "ssm.amazonaws.com",
-      },
-      "us-east-2": Object {
-        "ssm": "ssm.amazonaws.com",
-      },
-      "us-gov-east-1": Object {
-        "ssm": "ssm.amazonaws.com",
-      },
-      "us-gov-west-1": Object {
-        "ssm": "ssm.amazonaws.com",
-      },
-      "us-iso-east-1": Object {
-        "ssm": "ssm.amazonaws.com",
-      },
-      "us-iso-west-1": Object {
-        "ssm": "ssm.us-iso-west-1.amazonaws.com",
-      },
-      "us-isob-east-1": Object {
-        "ssm": "ssm.amazonaws.com",
-      },
-      "us-west-1": Object {
-        "ssm": "ssm.amazonaws.com",
-      },
-      "us-west-2": Object {
-        "ssm": "ssm.amazonaws.com",
-      },
-    },
-  },
   "Parameters": Object {
     "BootstrapVersion": Object {
       "Default": "/cdk-bootstrap/hnb659fds/version",
@@ -613,15 +479,7 @@ Object {
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Principal": Object {
-                "Service": Object {
-                  "Fn::FindInMap": Array [
-                    "ServiceprincipalMap",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    "ssm",
-                  ],
-                },
+                "Service": "ssm.amazonaws.com",
               },
             },
           ],

--- a/usecases/base-ct-logging/package.json
+++ b/usecases/base-ct-logging/package.json
@@ -22,7 +22,7 @@
     "@types/node": "18.7.14",
     "@typescript-eslint/eslint-plugin": "^5.38.0",
     "@typescript-eslint/parser": "^5.38.0",
-    "aws-cdk": "^2.43.1",
+    "aws-cdk": "^2.76.0",
     "eslint": "^8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "jest": "^27.5.1",
@@ -32,8 +32,8 @@
     "typescript": "~4.8.3"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.43.1",
-    "constructs": "^10.1.99",
+    "aws-cdk-lib": "^2.76.0",
+    "constructs": "^10.1.115",
     "source-map-support": "^0.5.21"
   }
 }

--- a/usecases/guest-core-banking-sample/package.json
+++ b/usecases/guest-core-banking-sample/package.json
@@ -22,7 +22,7 @@
     "@types/node": "18.7.14",
     "@typescript-eslint/eslint-plugin": "^5.38.0",
     "@typescript-eslint/parser": "^5.38.0",
-    "aws-cdk": "^2.43.1",
+    "aws-cdk": "^2.76.0",
     "eslint": "^8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "jest": "^27.5.1",
@@ -33,8 +33,8 @@
     "esbuild": "^0.15.9"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.43.1",
-    "constructs": "^10.1.99",
+    "aws-cdk-lib": "^2.76.0",
+    "constructs": "^10.1.115",
     "source-map-support": "^0.5.21"
   }
 }

--- a/usecases/guest-core-banking-sample/test/__snapshots__/bleafsi-guest-core-banking-sample.test.ts.snap
+++ b/usecases/guest-core-banking-sample/test/__snapshots__/bleafsi-guest-core-banking-sample.test.ts.snap
@@ -94,7 +94,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-111111111111-ap-northeast-1/0e295420383c769a3bfde9a50501a4f3c40a790ec2b83bc07a633afd50f3379a.json",
+              "/cdk-hnb659fds-assets-111111111111-ap-northeast-1/1f30003a73fbb991a989b1dbcb54d39b27e2da828404fe6d2e801b4ceadc9cd8.json",
             ],
           ],
         },
@@ -154,7 +154,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-111111111111-ap-northeast-1/0768b4ca20ae36696700beae769aa0b96d9b71166ebf4995a42e99ccbe67f952.json",
+              "/cdk-hnb659fds-assets-111111111111-ap-northeast-1/7ca112d6011ff98e37c11a68d8dc4ce128694addfa05ea0339d60414c6c245c7.json",
             ],
           ],
         },
@@ -253,7 +253,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-111111111111-ap-northeast-1/1eb2833bc5529e311fde443ef8f52d57dd73c9f41829a9f5316fc8665ae5f9d8.json",
+              "/cdk-hnb659fds-assets-111111111111-ap-northeast-1/5e4e74a008ff932370a24a0c2105273c0e80f6e349def495e8772e7bfe57cc2d.json",
             ],
           ],
         },
@@ -314,7 +314,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-111111111111-ap-northeast-1/f7d083d48f807303c4e72cae12e1ca66d64fa424305eedf12216d2e678d7dacb.json",
+              "/cdk-hnb659fds-assets-111111111111-ap-northeast-1/89bb146b989100757463fafd7b53c928e7192f88575ac0361bca942c0ba667aa.json",
             ],
           ],
         },
@@ -333,7 +333,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-111111111111-ap-northeast-1/d1d4de079e1e9e4b4ba20b948e4c008448fd6afd7bb3d5dce5691304aa0c0db7.json",
+              "/cdk-hnb659fds-assets-111111111111-ap-northeast-1/c55e8f611f3f9ef5740192195cda125c8e2fa33d00dda38b906eb6aef4ba322d.json",
             ],
           ],
         },
@@ -434,7 +434,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-111111111111-ap-northeast-3/58dd28e73cfd95fccc5da4562cd8c2e89bf2d732b93b450330ab599303d30f15.json",
+              "/cdk-hnb659fds-assets-111111111111-ap-northeast-3/6810dee919a3eff914b5b9ed4375fe51086104e404364b6482f1b93b79312bdb.json",
             ],
           ],
         },
@@ -464,7 +464,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-111111111111-ap-northeast-3/8e53639cd1d3948a7f50c82d39a536046a43e79304dd67037674b115c7fd1b92.json",
+              "/cdk-hnb659fds-assets-111111111111-ap-northeast-3/995fa6faefc5244138d373336f91c042b9ecee374d56ac4189297dd43a6c7bc6.json",
             ],
           ],
         },
@@ -524,7 +524,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-111111111111-ap-northeast-3/d88835e083f21d6cea1cb94f5ee6fb473191c7c3bfd5415a65e1091c935be91c.json",
+              "/cdk-hnb659fds-assets-111111111111-ap-northeast-3/d4f1c207e746a923030661fa74b34b1911d924cd4922d67b82d2c2a118dbd462.json",
             ],
           ],
         },
@@ -581,7 +581,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-111111111111-ap-northeast-3/36227a257de4aeb84e959830cbbbc23ebc48a39b881f689da5f0f89a485dd2a6.json",
+              "/cdk-hnb659fds-assets-111111111111-ap-northeast-3/ef3a0b9ceffa480ea4d490672a649b101c4fbd083390147c1968602f2ddf1992.json",
             ],
           ],
         },
@@ -619,7 +619,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-111111111111-ap-northeast-3/7f81fc94714b57ac5035b4b160392d26cadf2c69c48dad769246614656e05b40.json",
+              "/cdk-hnb659fds-assets-111111111111-ap-northeast-3/f184d060074929deb7a0a3f00075771990ba3801c96ca48bc964ed8b4345101e.json",
             ],
           ],
         },
@@ -694,7 +694,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": "cdk-hnb659fds-assets-111111111111-ap-northeast-1",
-          "S3Key": "6dbd112fe448437b3438da4382c72fccbb7d2ee1543db222620d7447fffebc50.zip",
+          "S3Key": "a9d3d4d1afa000946b9863b3e7578a5a5ad86d88274b3639938aa2baebf822ce.zip",
         },
         "Handler": "index.handler",
         "Role": Object {
@@ -838,7 +838,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-111111111111-ap-northeast-1/9156649b495a7c7f3cf81eded58053f70e6b955b0338ef48cc6321a8ded48dad.json",
+              "/cdk-hnb659fds-assets-111111111111-ap-northeast-1/e69729ccef5d491a15e2e7f0e15457bb54ded10c94c0a93eba6f35a4973b493a.json",
             ],
           ],
         },

--- a/usecases/guest-customer-channel-sample/lib/bleafsi-cr-connect/instance-storage-config.ts
+++ b/usecases/guest-customer-channel-sample/lib/bleafsi-cr-connect/instance-storage-config.ts
@@ -119,7 +119,7 @@ class InstanceStorageConfigProvider extends Construct {
     const onEventHandler = new NodejsFunction(this, 'OnEventHandler', {
       entry: path.join(__dirname, 'instance-storage-config.onEvent.ts'),
       handler: 'onEvent',
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       timeout: Duration.seconds(15),
       description:
         'Provider handler for Connect.associateInstanceStorageConfig() & disassociateInstanceStorageConfig()',

--- a/usecases/guest-customer-channel-sample/lib/bleafsi-cr-connect/instance.ts
+++ b/usecases/guest-customer-channel-sample/lib/bleafsi-cr-connect/instance.ts
@@ -63,7 +63,7 @@ class InstanceProvider extends Construct {
     const onEventHandler = new NodejsFunction(this, 'OnEventHandler', {
       entry: path.join(__dirname, 'instance.onEvent.ts'),
       handler: 'onEvent',
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       initialPolicy: [
         new iam.PolicyStatement({
           actions: [
@@ -105,7 +105,7 @@ class InstanceProvider extends Construct {
     const isCompleteHandler = new NodejsFunction(this, 'IsCompleteHandler', {
       entry: path.join(__dirname, 'instance.isComplete.ts'),
       handler: 'isComplete',
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       initialPolicy: [
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,

--- a/usecases/guest-customer-channel-sample/lib/bleafsi-cr-connect/lex-bot-association.ts
+++ b/usecases/guest-customer-channel-sample/lib/bleafsi-cr-connect/lex-bot-association.ts
@@ -47,7 +47,7 @@ class LexBotAssociationProvider extends Construct {
     const onEventHandler = new NodejsFunction(this, 'OnEventHandler', {
       entry: path.join(__dirname, 'lex-bot-association.onEvent.ts'),
       handler: 'onEvent',
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       timeout: Duration.seconds(15),
       description: 'Provider handler for Connect.associateBot() & disassociateBot()',
     });

--- a/usecases/guest-customer-channel-sample/package.json
+++ b/usecases/guest-customer-channel-sample/package.json
@@ -22,7 +22,7 @@
     "@types/node": "18.7.14",
     "@typescript-eslint/eslint-plugin": "^5.38.0",
     "@typescript-eslint/parser": "^5.38.0",
-    "aws-cdk": "^2.43.1",
+    "aws-cdk": "^2.76.0",
     "eslint": "^8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "jest": "^27.5.1",
@@ -34,11 +34,11 @@
     "esbuild": "^0.15.9"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.43.1",
-    "constructs": "^10.1.99",
+    "aws-cdk-lib": "^2.76.0",
+    "constructs": "^10.1.115",
     "source-map-support": "^0.5.21",
-    "aws-sdk": "^2.1189.0",
-    "cdk-nag": "^2.15.38",
+    "aws-sdk": "^2.1364.0",
+    "cdk-nag": "^2.26.5",
     "cdk-remote-stack": "^2.0.9"
   }
 }

--- a/usecases/guest-customer-channel-sample/test/__snapshots__/bleafsi-guest-customer-channel-sample.test.ts.snap
+++ b/usecases/guest-customer-channel-sample/test/__snapshots__/bleafsi-guest-customer-channel-sample.test.ts.snap
@@ -773,7 +773,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "19ce0a19474e5407b0fdb039e5ce700d8f4225638e1da6943193dde2b24290dd.zip",
+          "S3Key": "bf661023774aa4db87f644bf3abbd026b8816133ba70ae5f72999212fb18d484.zip",
         },
         "Description": "Provider handler for Connect.describeInstance()",
         "Environment": Object {
@@ -788,7 +788,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs16.x",
+        "Runtime": "nodejs18.x",
         "Timeout": 15,
       },
       "Type": "AWS::Lambda::Function",
@@ -882,7 +882,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "f6294eb79e4dc80740d85bee08dfe963fbede11251710f9d1b8077e6bf323746.zip",
+          "S3Key": "73fe0b3128fbe3c642191b448f0df468b3fd8e93fbebc92b3903a587434b6c4a.zip",
         },
         "Description": "Provider handler for Connect.createInstance() & deleteInstance()",
         "Environment": Object {
@@ -897,7 +897,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs16.x",
+        "Runtime": "nodejs18.x",
         "Timeout": 15,
       },
       "Type": "AWS::Lambda::Function",
@@ -1029,7 +1029,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "e7c95e1a12d903d913ebdd526c735f1ac58b2024882a5562110221fe685ebe85.zip",
+          "S3Key": "1eabd374284db340b74179e3429008132f5b6b0b7b28d472d852807d7f5f9746.zip",
         },
         "Description": "AWS CDK resource provider framework - isComplete (CustomerChannelPrimaryStack/InstanceProvider/Provider)",
         "Environment": Object {
@@ -1223,7 +1223,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "e7c95e1a12d903d913ebdd526c735f1ac58b2024882a5562110221fe685ebe85.zip",
+          "S3Key": "1eabd374284db340b74179e3429008132f5b6b0b7b28d472d852807d7f5f9746.zip",
         },
         "Description": "AWS CDK resource provider framework - onEvent (CustomerChannelPrimaryStack/InstanceProvider/Provider)",
         "Environment": Object {
@@ -1427,7 +1427,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "e7c95e1a12d903d913ebdd526c735f1ac58b2024882a5562110221fe685ebe85.zip",
+          "S3Key": "1eabd374284db340b74179e3429008132f5b6b0b7b28d472d852807d7f5f9746.zip",
         },
         "Description": "AWS CDK resource provider framework - onTimeout (CustomerChannelPrimaryStack/InstanceProvider/Provider)",
         "Environment": Object {
@@ -1779,7 +1779,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "283f6545fe88770043efdfe33e7f535da938a0b75503dce3f453f7d8cd4d30b9.zip",
+          "S3Key": "7ed0b981389980dc62372f1d3a3fb7ac97df0ca4aeac622a2eb59cdd4d05023e.zip",
         },
         "Description": "Provider handler for Connect.associateInstanceStorageConfig() & disassociateInstanceStorageConfig()",
         "Environment": Object {
@@ -1794,7 +1794,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs16.x",
+        "Runtime": "nodejs18.x",
         "Timeout": 15,
       },
       "Type": "AWS::Lambda::Function",
@@ -1971,7 +1971,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "e7c95e1a12d903d913ebdd526c735f1ac58b2024882a5562110221fe685ebe85.zip",
+          "S3Key": "1eabd374284db340b74179e3429008132f5b6b0b7b28d472d852807d7f5f9746.zip",
         },
         "Description": "AWS CDK resource provider framework - onEvent (CustomerChannelPrimaryStack/InstanceStorageConfigProvider/Provider)",
         "Environment": Object {
@@ -2115,7 +2115,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "d6eb194ff3c3896034c7a11eab11a5aee9c4d2c61a70b3c0e94309dbfa0e53fd.zip",
+          "S3Key": "625a09bc240db67276e10b43b64aef41e130c15582ecc7def6378456badbc809.zip",
         },
         "Description": "Provider handler for Connect.associateBot() & disassociateBot()",
         "Environment": Object {
@@ -2130,7 +2130,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs16.x",
+        "Runtime": "nodejs18.x",
         "Timeout": 15,
       },
       "Type": "AWS::Lambda::Function",
@@ -2260,7 +2260,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "e7c95e1a12d903d913ebdd526c735f1ac58b2024882a5562110221fe685ebe85.zip",
+          "S3Key": "1eabd374284db340b74179e3429008132f5b6b0b7b28d472d852807d7f5f9746.zip",
         },
         "Description": "AWS CDK resource provider framework - onEvent (CustomerChannelPrimaryStack/LexBotAssociationProvider/Provider)",
         "Environment": Object {
@@ -2418,7 +2418,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "eb5b005c858404ea0c8f68098ed5dcdf5340e02461f149751d10f59c210d5ef8.zip",
+          "S3Key": "f5b6a6d08a8206e67d0b54e2a29abd7e0472d835abc71037de3a93545b5edacc.zip",
         },
         "Handler": "index.handler",
         "Role": Object {
@@ -2997,7 +2997,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "e7c95e1a12d903d913ebdd526c735f1ac58b2024882a5562110221fe685ebe85.zip",
+          "S3Key": "1eabd374284db340b74179e3429008132f5b6b0b7b28d472d852807d7f5f9746.zip",
         },
         "Description": "AWS CDK resource provider framework - onEvent (CustomerChannelPrimaryStack/TertiaryStackOutputs/MyProvider)",
         "Environment": Object {
@@ -3666,7 +3666,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-southeast-1",
           },
-          "S3Key": "19ce0a19474e5407b0fdb039e5ce700d8f4225638e1da6943193dde2b24290dd.zip",
+          "S3Key": "bf661023774aa4db87f644bf3abbd026b8816133ba70ae5f72999212fb18d484.zip",
         },
         "Description": "Provider handler for Connect.describeInstance()",
         "Environment": Object {
@@ -3681,7 +3681,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs16.x",
+        "Runtime": "nodejs18.x",
         "Timeout": 15,
       },
       "Type": "AWS::Lambda::Function",
@@ -3775,7 +3775,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-southeast-1",
           },
-          "S3Key": "f6294eb79e4dc80740d85bee08dfe963fbede11251710f9d1b8077e6bf323746.zip",
+          "S3Key": "73fe0b3128fbe3c642191b448f0df468b3fd8e93fbebc92b3903a587434b6c4a.zip",
         },
         "Description": "Provider handler for Connect.createInstance() & deleteInstance()",
         "Environment": Object {
@@ -3790,7 +3790,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs16.x",
+        "Runtime": "nodejs18.x",
         "Timeout": 15,
       },
       "Type": "AWS::Lambda::Function",
@@ -3922,7 +3922,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-southeast-1",
           },
-          "S3Key": "e7c95e1a12d903d913ebdd526c735f1ac58b2024882a5562110221fe685ebe85.zip",
+          "S3Key": "1eabd374284db340b74179e3429008132f5b6b0b7b28d472d852807d7f5f9746.zip",
         },
         "Description": "AWS CDK resource provider framework - isComplete (CustomerChannelSecondaryStack/InstanceProvider/Provider)",
         "Environment": Object {
@@ -4116,7 +4116,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-southeast-1",
           },
-          "S3Key": "e7c95e1a12d903d913ebdd526c735f1ac58b2024882a5562110221fe685ebe85.zip",
+          "S3Key": "1eabd374284db340b74179e3429008132f5b6b0b7b28d472d852807d7f5f9746.zip",
         },
         "Description": "AWS CDK resource provider framework - onEvent (CustomerChannelSecondaryStack/InstanceProvider/Provider)",
         "Environment": Object {
@@ -4320,7 +4320,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-southeast-1",
           },
-          "S3Key": "e7c95e1a12d903d913ebdd526c735f1ac58b2024882a5562110221fe685ebe85.zip",
+          "S3Key": "1eabd374284db340b74179e3429008132f5b6b0b7b28d472d852807d7f5f9746.zip",
         },
         "Description": "AWS CDK resource provider framework - onTimeout (CustomerChannelSecondaryStack/InstanceProvider/Provider)",
         "Environment": Object {
@@ -4672,7 +4672,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-southeast-1",
           },
-          "S3Key": "283f6545fe88770043efdfe33e7f535da938a0b75503dce3f453f7d8cd4d30b9.zip",
+          "S3Key": "7ed0b981389980dc62372f1d3a3fb7ac97df0ca4aeac622a2eb59cdd4d05023e.zip",
         },
         "Description": "Provider handler for Connect.associateInstanceStorageConfig() & disassociateInstanceStorageConfig()",
         "Environment": Object {
@@ -4687,7 +4687,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs16.x",
+        "Runtime": "nodejs18.x",
         "Timeout": 15,
       },
       "Type": "AWS::Lambda::Function",
@@ -4887,7 +4887,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-southeast-1",
           },
-          "S3Key": "e7c95e1a12d903d913ebdd526c735f1ac58b2024882a5562110221fe685ebe85.zip",
+          "S3Key": "1eabd374284db340b74179e3429008132f5b6b0b7b28d472d852807d7f5f9746.zip",
         },
         "Description": "AWS CDK resource provider framework - onEvent (CustomerChannelSecondaryStack/InstanceStorageConfigProvider/Provider)",
         "Environment": Object {
@@ -5067,7 +5067,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-southeast-1",
           },
-          "S3Key": "eb5b005c858404ea0c8f68098ed5dcdf5340e02461f149751d10f59c210d5ef8.zip",
+          "S3Key": "f5b6a6d08a8206e67d0b54e2a29abd7e0472d835abc71037de3a93545b5edacc.zip",
         },
         "Handler": "index.handler",
         "Role": Object {
@@ -5292,7 +5292,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-southeast-1",
           },
-          "S3Key": "e7c95e1a12d903d913ebdd526c735f1ac58b2024882a5562110221fe685ebe85.zip",
+          "S3Key": "1eabd374284db340b74179e3429008132f5b6b0b7b28d472d852807d7f5f9746.zip",
         },
         "Description": "AWS CDK resource provider framework - onEvent (CustomerChannelSecondaryStack/TertiaryStackOutputs/MyProvider)",
         "Environment": Object {

--- a/usecases/guest-market-data-sample/package.json
+++ b/usecases/guest-market-data-sample/package.json
@@ -22,7 +22,7 @@
     "@types/node": "18.7.14",
     "@typescript-eslint/eslint-plugin": "^5.38.0",
     "@typescript-eslint/parser": "^5.38.0",
-    "aws-cdk": "^2.43.1",
+    "aws-cdk": "^2.76.0",
     "eslint": "^8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "jest": "^27.5.1",
@@ -32,8 +32,8 @@
     "typescript": "~4.8.3"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.43.1",
-    "constructs": "^10.1.99",
+    "aws-cdk-lib": "^2.76.0",
+    "constructs": "^10.1.115",
     "source-map-support": "^0.5.21"
   }
 }

--- a/usecases/guest-market-data-sample/test/__snapshots__/bleafsi-guest-market-data.test.ts.snap
+++ b/usecases/guest-market-data-sample/test/__snapshots__/bleafsi-guest-market-data.test.ts.snap
@@ -114,7 +114,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-111111111111-ap-northeast-1/02f43b43f063bfd765f782ae49c4b248d7155ecf3d49734ad6ff67b20f75d36d.json",
+              "/cdk-hnb659fds-assets-111111111111-ap-northeast-1/4e821f59274b6885b7521fed6438383cfdee85769d90e1c73f10fb6d33c521af.json",
             ],
           ],
         },
@@ -213,7 +213,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-111111111111-ap-northeast-1/f6d225ef472a63c2cc3109517fe1656c34e36d23a210696652157ed9bfbe74f9.json",
+              "/cdk-hnb659fds-assets-111111111111-ap-northeast-1/6ab2a37d311f302e1610dfad8f46e2e0d015606915a41888304a9c0a3057102c.json",
             ],
           ],
         },
@@ -333,7 +333,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-111111111111-ap-northeast-1/ebfbf7b94ae8ab1295e1c2b8b1e182f70fe2609f3d10a0a92ec19076d76ad27a.json",
+              "/cdk-hnb659fds-assets-111111111111-ap-northeast-1/a6ee4bf5e19fa4af8fbed8a79d9ff90b4c861bdaefc815d999d33fffa0179dd2.json",
             ],
           ],
         },
@@ -379,7 +379,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-111111111111-ap-northeast-1/4e1be6122552f0d1fa8a8de57083a5e8c11abb6270e53f6038c74f81c6c32a20.json",
+              "/cdk-hnb659fds-assets-111111111111-ap-northeast-1/948d8f1282db27e400c459704ff6ca2ca835bba1d996cae4fc4e60b3bbc45b4c.json",
             ],
           ],
         },
@@ -456,9 +456,6 @@ Object {
             ],
           },
         },
-        "StreamModeDetails": Object {
-          "StreamMode": "PROVISIONED",
-        },
       },
       "Type": "AWS::Kinesis::Stream",
     },
@@ -474,9 +471,6 @@ Object {
               "Outputs.BLEAFSImarketdataBLEAFSIAppKey1685CF6DArn",
             ],
           },
-        },
-        "StreamModeDetails": Object {
-          "StreamMode": "PROVISIONED",
         },
       },
       "Type": "AWS::Kinesis::Stream",

--- a/usecases/guest-openapi-base-sample/lib/bleafsi-openapi-base-sample-stack.ts
+++ b/usecases/guest-openapi-base-sample/lib/bleafsi-openapi-base-sample-stack.ts
@@ -50,7 +50,7 @@ export class SampleOpenApiStack extends cdk.Stack {
     });
 
     const hello = new lambda.Function(this, 'HelloHandler', {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromAsset('lambda'),
       handler: 'hello.handler',
     });

--- a/usecases/guest-openapi-base-sample/package.json
+++ b/usecases/guest-openapi-base-sample/package.json
@@ -22,7 +22,7 @@
     "@types/node": "18.7.14",
     "@typescript-eslint/eslint-plugin": "^5.38.0",
     "@typescript-eslint/parser": "^5.38.0",
-    "aws-cdk": "^2.43.1",
+    "aws-cdk": "^2.76.0",
     "eslint": "^8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "jest": "^27.5.1",
@@ -32,8 +32,8 @@
     "typescript": "~4.8.3"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.43.1",
-    "constructs": "^10.1.99",
+    "aws-cdk-lib": "^2.76.0",
+    "constructs": "^10.1.115",
     "source-map-support": "^0.5.21"
   }
 }

--- a/usecases/guest-openapi-base-sample/test/__snapshots__/guest-openapi-sample.test.ts.snap
+++ b/usecases/guest-openapi-base-sample/test/__snapshots__/guest-openapi-sample.test.ts.snap
@@ -64,7 +64,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs16.x",
+        "Runtime": "nodejs18.x",
       },
       "Type": "AWS::Lambda::Function",
     },

--- a/usecases/guest-openapi-fapi-sample/package.json
+++ b/usecases/guest-openapi-fapi-sample/package.json
@@ -22,7 +22,7 @@
     "@types/node": "18.7.14",
     "@typescript-eslint/eslint-plugin": "^5.38.0",
     "@typescript-eslint/parser": "^5.38.0",
-    "aws-cdk": "^2.43.1",
+    "aws-cdk": "^2.76.0",
     "eslint": "^8.23.1",
     "eslint-config-prettier": "^8.5.0",
     "jest": "^27.5.1",
@@ -32,8 +32,8 @@
     "typescript": "~4.8.3"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.43.1",
-    "constructs": "^10.1.99",
+    "aws-cdk-lib": "^2.76.0",
+    "constructs": "^10.1.115",
     "source-map-support": "^0.5.21"
   }
 }

--- a/usecases/guest-openapi-fapi-sample/test/__snapshots__/bleafsi-guest-openapi-fapi-sample.test.ts.snap
+++ b/usecases/guest-openapi-fapi-sample/test/__snapshots__/bleafsi-guest-openapi-fapi-sample.test.ts.snap
@@ -115,7 +115,7 @@ Object {
               Object {
                 "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
               },
-              "/822e4caa9eec0d3bb9d438613588813ad45a73cf25bc1a6c0294a7e2d79d474d.json",
+              "/cf7a0c2c8547c3307239ca63b45fd839624562b08218d8da57676cf37825002f.json",
             ],
           ],
         },
@@ -138,7 +138,7 @@ Object {
               Object {
                 "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
               },
-              "/86c5ebdc900fb4425229a1de026f431c9eb4cb841905c65a9fa9ad862f1e63d1.json",
+              "/967427b2bf7025a8ab5088a80ca68f4da20bba9e250d7cdc163580d319667d4a.json",
             ],
           ],
         },
@@ -299,7 +299,6 @@ Object {
           "Ref": "KeycloakDatabaseDBClusterSubnets28319191",
         },
         "Engine": "aurora-mysql",
-        "EngineVersion": "5.7.mysql_aurora.2.09.1",
         "PubliclyAccessible": false,
       },
       "Type": "AWS::RDS::DBInstance",
@@ -316,7 +315,6 @@ Object {
           "Ref": "KeycloakDatabaseDBClusterSubnets28319191",
         },
         "Engine": "aurora-mysql",
-        "EngineVersion": "5.7.mysql_aurora.2.09.1",
         "PubliclyAccessible": false,
       },
       "Type": "AWS::RDS::DBInstance",


### PR DESCRIPTION
fix available via `npm audit fix`
node_modules/xml2js
  aws-sdk  <=2.1353.0
  Depends on vulnerable versions of xml2js
  node_modules/aws-sdk

yaml  <2.2.2
Severity: moderate
